### PR TITLE
Fix workflow cron and force push to docs branch

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -4,7 +4,7 @@ name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 on:
   # Runs on pushes targeting the default branch
   schedule:
-    - cron: "1 * * * 1"
+    - cron: "0 1 * * 1"
   push:
     branches: ["devel"]
 
@@ -59,6 +59,8 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           branch: docs
+          push_options: '--force'
+          skip_checkout: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .bundle
 vendor
 Gemfile.lock
+.vscode

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: "AAP Configuration as Code Docs"
-url: "https://djdanielsson.github.io/aap_config_as_code_docs/"
+url: "https://redhat-cop.github.io/aap_config_as_code_docs/"
 avatar: https://raw.githubusercontent.com/barryclark/jekyll-now/master/images/jekyll-logo.png
 # theme: just-the-docs
 remote_theme: just-the-docs/just-the-docs


### PR DESCRIPTION
Fixes an issue with the cron that meant it was being run at 1 minute past the hour, every hour on a Monday.

Also fixes issue where we cant run the workflow because changes will be overriden in the git checkout of the branch. Instead we should just force push to the branch without pulling first